### PR TITLE
APAAS-2751 Use Docker log file

### DIFF
--- a/lib/stackato/logyard.rb
+++ b/lib/stackato/logyard.rb
@@ -41,7 +41,6 @@ module Stackato
        :docker_id => options[:docker_id],
        :rootpath => options[:rootfs],
        :logfiles => options[:logfiles],
-       :docker_streams => options[:docker_streams],
       }
       key = "#{apptail_nats_msg_prefix}.newinstance"
       logger.info("Publishing to #{key}: #{msg}")


### PR DESCRIPTION
Apptail should use the json-file formatted Docker log file instead of
streaming through the API.  That way we can separate stdout and stderr
again, and even get more accurate timestamps.

apptail will detect the docker log by the special "_docker_" stream
name, so the docker_streams argument becomes redundant.
